### PR TITLE
Modified starting job message

### DIFF
--- a/src/main/kotlin/com/timcastelijns/room15bot/util/MessageFormatter.kt
+++ b/src/main/kotlin/com/timcastelijns/room15bot/util/MessageFormatter.kt
@@ -58,7 +58,7 @@ class MessageFormatter {
         table.joinToString("\n") { "    $it" }
     }
 
-    fun asStartingJobString() = "Ok, give me a second"
+    fun asStartingJobString() = "Ok, give me a minute."
 
     fun asDoneString(measuredTime: Long) = "Done, took $measuredTime ms"
 


### PR DESCRIPTION
The bot will now say that it needs a minute instead of a second, to better represent how long he's going to take to do its job.